### PR TITLE
Use httpx[brotli] instead of very old brotlipy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,13 +9,12 @@ dependencies = [
     "click>=8.1.7",
     "xdg-base-dirs>=6.0.1",
     "click-default-group>=1.2.4",
-    "httpx>=0.27.0",
+    "httpx[brotli]>=0.27.0",
     "textual-autocomplete>=3.0.0a3",
     "pyperclip>=1.8.2",
     "pydantic>=2.7.3",
     "pyyaml>=6.0.1",
     "textual[syntax]>=0.70.0",
-    "brotlipy>=0.7.0",
 ]
 readme = "README.md"
 requires-python = ">= 3.11"

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -6,6 +6,7 @@
 #   features: []
 #   all-features: false
 #   with-sources: false
+#   generate-hashes: false
 
 -e file:.
 aiohttp==3.9.5
@@ -18,13 +19,11 @@ anyio==4.4.0
     # via httpx
 attrs==23.2.0
     # via aiohttp
-brotlipy==0.7.0
-    # via posting
+brotli==1.1.0
+    # via httpx
 certifi==2024.2.2
     # via httpcore
     # via httpx
-cffi==1.16.0
-    # via brotlipy
 click==8.1.7
     # via click-default-group
     # via posting
@@ -59,8 +58,6 @@ msgpack==1.0.8
 multidict==6.0.5
     # via aiohttp
     # via yarl
-pycparser==2.22
-    # via cffi
 pydantic==2.7.3
     # via posting
 pydantic-core==2.18.4

--- a/requirements.lock
+++ b/requirements.lock
@@ -6,19 +6,18 @@
 #   features: []
 #   all-features: false
 #   with-sources: false
+#   generate-hashes: false
 
 -e file:.
 annotated-types==0.7.0
     # via pydantic
 anyio==4.4.0
     # via httpx
-brotlipy==0.7.0
-    # via posting
+brotli==1.1.0
+    # via httpx
 certifi==2024.2.2
     # via httpcore
     # via httpx
-cffi==1.16.0
-    # via brotlipy
 click==8.1.7
     # via click-default-group
     # via posting
@@ -43,8 +42,6 @@ mdit-py-plugins==0.4.1
     # via markdown-it-py
 mdurl==0.1.2
     # via markdown-it-py
-pycparser==2.22
-    # via cffi
 pydantic==2.7.3
     # via posting
 pydantic-core==2.18.4


### PR DESCRIPTION
Brotlipy does not seem to even compile on ARM-based Macs. At least I keep getting inscrutable error messages when it tries to compile. I noticed that brotlipy was last released in 2017 and that the posting code does not use it directly anywhere. It _does_ use httpx, which can be installed with brotli support using `pip install httpx[brotli]`. This PR tries to remedy the situation.