### PR TITLE
Various updates

### DIFF
--- a/src/posting/config.py
+++ b/src/posting/config.py
@@ -74,6 +74,18 @@ class Settings(BaseSettings):
     pager: str | None = Field(default=os.getenv("PAGER"))
     """The command to use for paging."""
 
+    pager_json: str | None = Field(default=None)
+    """The command to use for paging JSON.
+    
+    This will be used when the pager is opened from within a TextArea,
+    and the content within that TextArea can be inferred to be JSON.
+    
+    For example, the editor is set to JSON language, or the response content
+    type indicates JSON.
+
+    If this is unset, the standard `pager` config will be used.
+    """
+
     editor: str | None = Field(default=os.getenv("EDITOR"))
     """The command to use for editing."""
 

--- a/src/posting/widgets/response/response_area.py
+++ b/src/posting/widgets/response/response_area.py
@@ -77,7 +77,9 @@ class ResponseArea(Vertical):
         response_settings = SETTINGS.get().response
         if response_text_area.language == "json" and response_settings.prettify_json:
             try:
-                response_text = json.dumps(json.loads(response_text), indent=2)
+                response_text = json.dumps(
+                    json.loads(response_text), indent=2, ensure_ascii=False
+                )
             except json.JSONDecodeError:
                 pass
 

--- a/src/posting/widgets/text_area.py
+++ b/src/posting/widgets/text_area.py
@@ -238,7 +238,15 @@ class PostingTextArea(TextArea):
         self._open_as_tempfile(editor_command)
 
     def action_open_in_pager(self) -> None:
-        pager_command = SETTINGS.get().pager
+        settings = SETTINGS.get()
+
+        # If the language is JSON and the user has declared they
+        # want to use a specific pager for JSON, let's use that.
+        if self.language == "json" and settings.pager_json:
+            pager_command = settings.pager_json
+        else:
+            pager_command = settings.pager
+
         self._open_as_tempfile(pager_command)
 
     def _open_as_tempfile(self, command: str | None) -> None:

--- a/src/posting/widgets/text_area.py
+++ b/src/posting/widgets/text_area.py
@@ -317,6 +317,8 @@ class ReadOnlyTextArea(PostingTextArea):
         Binding(
             "y,c", "copy_to_clipboard", description="Copy selection", key_display="y"
         ),
+        Binding("g", "cursor_top", "Go to top", show=False),
+        Binding("G", "cursor_bottom", "Go to bottom", show=False),
     ]
 
     def __init__(
@@ -410,6 +412,12 @@ class ReadOnlyTextArea(PostingTextArea):
 
         pyperclip.copy(text_to_copy)
         self.visual_mode = False
+
+    def action_cursor_top(self) -> None:
+        self.selection = Selection.cursor((0, 0))
+
+    def action_cursor_bottom(self) -> None:
+        self.selection = Selection.cursor((self.document.line_count - 1, 0))
 
 
 class TextEditor(Vertical):


### PR DESCRIPTION
- Ensure Unicode is rendered in JSON responses.
- Add new hotkeys to the response area:
	- `g` - move cursor to first line of response
	- `G` - move cursor to last line of response
	- `%` - move cursor to matching bracket
- Allow `POSTING_PAGER_JSON` config - allows you to use a custom pager for JSON responses (e.g. `fx`).

