### PR TITLE
CA config, renaming tabs

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,13 +255,15 @@ Dotenv files are separate from collections, although you may wish to include the
 | `heading.visible` (`POSTING_HEADING__VISIBLE`) | `true`, `false` (Default: `true`) | Show/hide the app header. |
 | `heading.show_host` (`POSTING_HEADING__SHOW_HOST`) | `true`, `false` (Default: `true`) | Show/hide the hostname in the app header. |
 | `url_bar.show_value_preview` (`POSTING_URL_BAR__SHOW_VALUE_PREVIEW`) | `true`, `false` (Default: `true`) | Show/hide the variable value preview below the URL bar. |
-| `pager` (`POSTING_PAGER`) | Command to use for paging text. |
-| `pager_json` (`POSTING_PAGER_JSON`) | Command to use for paging JSON. |
-| `editor` (`POSTING_EDITOR`) | Command to use for opening files in an external editor. |
+| `pager` (`POSTING_PAGER`) | (Default: `$PAGER`) | Command to use for paging text. |
+| `pager_json` (`POSTING_PAGER_JSON`) | (Default: `$PAGER`) | Command to use for paging JSON. |
+| `editor` (`POSTING_EDITOR`) | (Default: `$EDITOR`) | Command to use for opening files in an external editor. |
 | `ssl.verify` (`POSTING_SSL__VERIFY`) | `true`, `false` (Default: `true`) | If enabled, SSL certificates will be verified. |
-| `ssl.certificate_path` (`POSTING_SSL__CERTIFICATE_PATH`) | Path to a `.pem` (file or directory). |
-| `ssl.key_file` (`POSTING_SSL__KEY_FILE`) | Path to a keyfile. |
-| `ssl.password` (`POSTING_SSL__PASSWORD`) | Password for the key file. |
+| `ssl.certificate_path` (`POSTING_SSL__CERTIFICATE_PATH`) | Absolute path to a `.pem` (file or directory). (Default: `unset`) | Path to the SSL certificate file or directory. |
+| `ssl.key_file` (`POSTING_SSL__KEY_FILE`) | Absolute path to a keyfile. (Default: `unset`) | Path to the keyfile. |
+| `ssl.password` (`POSTING_SSL__PASSWORD`) | Password for the key file. (Default: `unset`) | Password to decrypt the SSL key file if it's encrypted. |
+| `focus.on_startup` (`POSTING_FOCUS__ON_STARTUP`) | `"url"`, `"method", "collection"` (Default: `"url"`) | Automatically focus the URL bar, method, or collection browser when the app starts. |
+| `focus.on_response` (`POSTING_FOCUS__ON_RESPONSE`) | `"body"`, `"tabs"` (Default: `unset`)| Automatically focus the response tabs or response body text area when a response is received. |
 
 ## Loading SSL certificates
 

--- a/README.md
+++ b/README.md
@@ -255,6 +255,10 @@ POSTING_HEADING__VISIBLE="false"
 | `pager` (`POSTING_PAGER`) | Command to use for paging text. |
 | `pager_json` (`POSTING_PAGER_JSON`) | Command to use for paging JSON. |
 | `editor` (`POSTING_EDITOR`) | Command to use for opening files in an external editor. |
+| `ssl.verify` (`POSTING_SSL__VERIFY`) | `true`, `false` (Default: `true`) | If enabled, SSL certificates will be verified. |
+| `ssl.certificate_file` (`POSTING_SSL__CERTIFICATE_FILE`) | Path to a `.pem` certificate bundle (file or dir). |
+| `ssl.key_file` (`POSTING_SSL__KEY_FILE`) | Path to a keyfile. |
+| `ssl.password` (`POSTING_SSL__PASSWORD`) | Password for the key file. |
 
 
 ## Importing OpenAPI Specifications

--- a/README.md
+++ b/README.md
@@ -228,9 +228,10 @@ For example, to set the theme to `galaxy`, you can set the environment variable 
 
 ### dotenv (`.env`) files
 
-Posting also supports `.env` (dotenv) files, which are useful if you want to keep your configuration in a file rather than in your shell's environment variables.
+Posting also supports `.env` (dotenv) files, which are useful if you want to swap out environment variable values depending on the environment you're working in (for example, "dev" vs "prod").
 
-You can tell Posting to use a `.env` file using the `--env-file` option.
+You can tell Posting to use a `.env` file using the `--env` option.
+This option can be supplied multiple times to load multiple `.env` files.
 
 Here's an example `.env` file:
 
@@ -239,6 +240,8 @@ POSTING_THEME="cobalt"
 POSTING_LAYOUT="vertical"
 POSTING_HEADING__VISIBLE="false"
 ```
+
+Dotenv files are separate from collections, although you may wish to include them inside a collection to make it easy to version and share with others.
 
 ### Available configuration options
 
@@ -256,10 +259,39 @@ POSTING_HEADING__VISIBLE="false"
 | `pager_json` (`POSTING_PAGER_JSON`) | Command to use for paging JSON. |
 | `editor` (`POSTING_EDITOR`) | Command to use for opening files in an external editor. |
 | `ssl.verify` (`POSTING_SSL__VERIFY`) | `true`, `false` (Default: `true`) | If enabled, SSL certificates will be verified. |
-| `ssl.certificate_file` (`POSTING_SSL__CERTIFICATE_FILE`) | Path to a `.pem` certificate bundle (file or dir). |
+| `ssl.certificate_path` (`POSTING_SSL__CERTIFICATE_PATH`) | Path to a `.pem` (file or directory). |
 | `ssl.key_file` (`POSTING_SSL__KEY_FILE`) | Path to a keyfile. |
 | `ssl.password` (`POSTING_SSL__PASSWORD`) | Password for the key file. |
 
+## Loading SSL certificates
+
+Posting can load SSL certificates from a `.pem` file or directory.
+
+The easiest way to do this is in your `config.yaml` file:
+
+```yaml
+ssl:
+  certificate_path: 'absolute/path/to/certificate.pem'
+  key_file: 'absolute/path/to/key.key'
+  password: '***********'
+```
+
+### Environment-specific certificates
+
+If the required CA bundle differs per environment, you can again use the principle that all configuration can be set as environment variables which can optionally be set and loaded using `--env` and `.env` files:
+
+```bash
+# dev.env
+POSTING_SSL__CERTIFICATE_PATH='/path/to/certificate.pem'
+POSTING_SSL__KEY_FILE='/path/to/key.key'
+POSTING_SSL__PASSWORD='***********'
+```
+
+Now load the `dev.env` file when working in the `dev` environment to ensure the dev environment certificate is used:
+
+```bash
+posting --env dev.env
+```
 
 ## Importing OpenAPI Specifications
 

--- a/README.md
+++ b/README.md
@@ -259,9 +259,9 @@ Dotenv files are separate from collections, although you may wish to include the
 | `pager_json` (`POSTING_PAGER_JSON`) | (Default: `$PAGER`) | Command to use for paging JSON. |
 | `editor` (`POSTING_EDITOR`) | (Default: `$EDITOR`) | Command to use for opening files in an external editor. |
 | `ssl.verify` (`POSTING_SSL__VERIFY`) | `true`, `false` (Default: `true`) | If enabled, SSL certificates will be verified. |
-| `ssl.certificate_path` (`POSTING_SSL__CERTIFICATE_PATH`) | Absolute path to a `.pem` (file or directory). (Default: `unset`) | Path to the SSL certificate file or directory. |
-| `ssl.key_file` (`POSTING_SSL__KEY_FILE`) | Absolute path to a keyfile. (Default: `unset`) | Path to the keyfile. |
-| `ssl.password` (`POSTING_SSL__PASSWORD`) | Password for the key file. (Default: `unset`) | Password to decrypt the SSL key file if it's encrypted. |
+| `ssl.certificate_path` (`POSTING_SSL__CERTIFICATE_PATH`) | Absolute path (Default: `unset`) | Absolute path to the SSL certificate file or directory. |
+| `ssl.key_file` (`POSTING_SSL__KEY_FILE`) | Absolute path (Default: `unset`) | Absolute path to the SSL key file. |
+| `ssl.password` (`POSTING_SSL__PASSWORD`) | Password for the key file. (Default: `unset`) | Password to decrypt the key file if it's encrypted. |
 | `focus.on_startup` (`POSTING_FOCUS__ON_STARTUP`) | `"url"`, `"method", "collection"` (Default: `"url"`) | Automatically focus the URL bar, method, or collection browser when the app starts. |
 | `focus.on_response` (`POSTING_FOCUS__ON_RESPONSE`) | `"body"`, `"tabs"` (Default: `unset`)| Automatically focus the response tabs or response body text area when a response is received. |
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,10 +13,10 @@ dependencies = [
     "pyperclip==1.8.2",
     "pydantic==2.7.3",
     "pyyaml==6.0.1",
-    "textual[syntax]==0.72.0",
     "pydantic-settings==2.3.4",
     "python-dotenv==1.0.1",
     "textual-autocomplete>=3.0.0a9",
+    "textual[syntax]==0.72.0",
 ]
 readme = "README.md"
 requires-python = ">= 3.11"

--- a/src/posting/app.py
+++ b/src/posting/app.py
@@ -577,6 +577,7 @@ class PostingApp(App[None]):
 
 
 class Posting(PostingApp):
+    AUTO_FOCUS = None
     COMMANDS = {PostingProvider}
     CSS_PATH = Path(__file__).parent / "posting.scss"
     BINDINGS = [
@@ -814,6 +815,10 @@ class Posting(PostingApp):
         self._jumping = not self._jumping
 
     async def watch__jumping(self, jumping: bool) -> None:
+        focused_before = self.focused
+        if focused_before is not None:
+            self.set_focus(None, scroll_visible=False)
+
         def handle_jump_target(target: str | Widget | None) -> None:
             if isinstance(target, str):
                 try:
@@ -832,6 +837,11 @@ class Posting(PostingApp):
 
             elif isinstance(target, Widget):
                 target.focus()
+            else:
+                # If there's no target (i.e. the user pressed ESC to dismiss)
+                # then re-focus the widget that was focused before we opened
+                # the jumper.
+                self.set_focus(focused_before, scroll_visible=False)
 
         self.clear_notifications()
         await self.push_screen(JumpOverlay(self.jumper), callback=handle_jump_target)

--- a/src/posting/app.py
+++ b/src/posting/app.py
@@ -383,11 +383,11 @@ class MainScreen(Screen[None]):
         self, event: PostingDataTable.RowsRemoved | PostingDataTable.RowsAdded
     ) -> None:
         """Update the parameters tab to indicate if there are any parameters."""
-        params_tab = self.query_one("#--content-tab-parameters-pane", ContentTab)
+        params_tab = self.query_one("#--content-tab-query-pane", ContentTab)
         if event.data_table.row_count:
-            params_tab.update("Parameters[cyan b]•[/]")
+            params_tab.update("Query[cyan b]•[/]")
         else:
-            params_tab.update("Parameters")
+            params_tab.update("Query")
 
     def build_httpx_request(
         self,
@@ -699,9 +699,9 @@ class Posting(PostingApp):
                 "collection-tree": "tab",
                 "--content-tab-headers-pane": "q",
                 "--content-tab-body-pane": "w",
-                "--content-tab-parameters-pane": "e",
+                "--content-tab-query-pane": "e",
                 "--content-tab-auth-pane": "r",
-                "--content-tab-metadata-pane": "t",
+                "--content-tab-info-pane": "t",
                 "--content-tab-options-pane": "y",
                 "--content-tab-response-body-pane": "a",
                 "--content-tab-response-headers-pane": "s",

--- a/src/posting/app.py
+++ b/src/posting/app.py
@@ -162,10 +162,10 @@ class MainScreen(Screen[None]):
         timeout = request_options.timeout
         auth = self.request_auth.to_httpx_auth()
 
-        ca_config = SETTINGS.get().certificate
+        ca_config = SETTINGS.get().ssl
         cert_config: list[str] = []
-        if certificate_file := ca_config.certificate_file:
-            cert_config.append(certificate_file)
+        if certificate_path := ca_config.certificate_path:
+            cert_config.append(certificate_path)
         if key_file := ca_config.key_file:
             cert_config.append(key_file)
         if password := ca_config.password:

--- a/src/posting/config.py
+++ b/src/posting/config.py
@@ -1,7 +1,7 @@
 from contextvars import ContextVar
 import os
 from typing import Type
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, SecretStr
 from pydantic_settings import (
     BaseSettings,
     PydanticBaseSettingsSource,
@@ -36,6 +36,17 @@ class ResponseSettings(BaseModel):
 
     prettify_json: bool = Field(default=True)
     """If enabled, JSON responses will be pretty-formatted."""
+
+
+class CertificateSettings(BaseModel):
+    """Configuration for SSL CA bundles"""
+
+    certificate_file: str | None = Field(default=None)
+    """Path to the certificate .pem file"""
+    key_file: str | None = Field(default=None)
+    """Path to the key file"""
+    password: SecretStr | None = Field(default=None)
+    """Password for the key file."""
 
 
 class Settings(BaseSettings):
@@ -88,6 +99,9 @@ class Settings(BaseSettings):
 
     editor: str | None = Field(default=os.getenv("EDITOR"))
     """The command to use for editing."""
+
+    ssl: CertificateSettings = Field(default_factory=CertificateSettings)
+    """Configuration for SSL CA bundle."""
 
     @classmethod
     def settings_customise_sources(

--- a/src/posting/config.py
+++ b/src/posting/config.py
@@ -41,8 +41,8 @@ class ResponseSettings(BaseModel):
 class CertificateSettings(BaseModel):
     """Configuration for SSL CA bundles"""
 
-    certificate_file: str | None = Field(default=None)
-    """Path to the certificate .pem file"""
+    certificate_path: str | None = Field(default=None)
+    """Path to the certificate .pem file or directory"""
     key_file: str | None = Field(default=None)
     """Path to the key file"""
     password: SecretStr | None = Field(default=None)

--- a/src/posting/config.py
+++ b/src/posting/config.py
@@ -1,6 +1,6 @@
 from contextvars import ContextVar
 import os
-from typing import Type
+from typing import Literal, Type
 from pydantic import BaseModel, Field, SecretStr
 from pydantic_settings import (
     BaseSettings,
@@ -36,6 +36,18 @@ class ResponseSettings(BaseModel):
 
     prettify_json: bool = Field(default=True)
     """If enabled, JSON responses will be pretty-formatted."""
+
+
+class FocusSettings(BaseModel):
+    """Configuration relating to focus."""
+
+    on_startup: Literal["url", "method", "collection"] = Field(default="url")
+    """On startup, move focus to the URL bar, method, or collection browser."""
+
+    on_response: Literal["body", "tabs"] | None = Field(default=None)
+    """On receiving a response, move focus to the body or the response section (the tabs).
+    
+    If this value is unset, focus will not shift when a response is received."""
 
 
 class CertificateSettings(BaseModel):
@@ -102,6 +114,9 @@ class Settings(BaseSettings):
 
     ssl: CertificateSettings = Field(default_factory=CertificateSettings)
     """Configuration for SSL CA bundle."""
+
+    focus: FocusSettings = Field(default_factory=FocusSettings)
+    """Configuration for focus."""
 
     @classmethod
     def settings_customise_sources(

--- a/src/posting/types.py
+++ b/src/posting/types.py
@@ -1,3 +1,13 @@
-from typing import Literal
+from typing import Literal, Optional, Tuple, Union
 
 PostingLayout = Literal["horizontal", "vertical"]
+
+# From httpx - seems to not be public.
+CertTypes = Union[
+    # certfile
+    str,
+    # (certfile, keyfile)
+    Tuple[str, Optional[str]],
+    # (certfile, keyfile, password)
+    Tuple[str, Optional[str], Optional[str]],
+]

--- a/src/posting/widgets/request/request_editor.py
+++ b/src/posting/widgets/request/request_editor.py
@@ -80,11 +80,11 @@ class RequestEditor(Vertical):
                         yield FormEditor(
                             id="form-body-editor",
                         )
-                with TabPane("Parameters", id="parameters-pane"):
+                with TabPane("Query", id="query-pane"):
                     yield QueryStringEditor()
                 with TabPane("Auth", id="auth-pane"):
                     yield RequestAuth()
-                with TabPane("Metadata", id="metadata-pane"):
+                with TabPane("Info", id="info-pane"):
                     yield RequestMetadata()
                 with TabPane("Options", id="options-pane"):
                     yield RequestOptions()

--- a/src/posting/widgets/request/url_bar.py
+++ b/src/posting/widgets/request/url_bar.py
@@ -297,3 +297,8 @@ class UrlBar(Vertical):
     def variable_value_bar(self) -> Label:
         """Get the variable value bar."""
         return self.query_one("#variable-value-bar", Label)
+
+    @property
+    def url_input(self) -> UrlInput:
+        """Get the URL input."""
+        return self.query_one("#url-input", UrlInput)

--- a/src/posting/widgets/response/response_area.py
+++ b/src/posting/widgets/response/response_area.py
@@ -13,6 +13,7 @@ from textual.app import ComposeResult
 from textual.containers import Vertical
 from textual.reactive import Reactive, reactive
 from textual.widgets import TabPane
+from textual.widgets._tabbed_content import ContentTabs
 
 
 class ResponseTabbedContent(PostingTabbedContent):
@@ -123,6 +124,14 @@ class ResponseArea(Vertical):
     @property
     def cookies_table(self) -> CookiesTable:
         return self.query_one(CookiesTable)
+
+    @property
+    def tabbed_content(self) -> ResponseTabbedContent:
+        return self.query_one(ResponseTabbedContent)
+
+    @property
+    def content_tabs(self) -> ContentTabs:
+        return self.tabbed_content.query_one(ContentTabs)
 
 
 def content_type_to_language(content_type: str) -> str | None:


### PR DESCRIPTION
- Adds support for specifying custom CA bundles (3 new configuration items inside `ssl` config section)
- Adds "focus shifts" - configurable automatic focus shifting in `focus` config section:
  - `focus.on_startup` to choose which widget gets focused on app launch.
  - `focus.on_response` to auto-shift focus on receiving a response.
- Fixes jump mode issue when initiated while an input field was focused.
- Renames `Metadata` tab to `Info`
- Renames `Parameters` tab to `Query`