### PR TITLE
Various changes/improvements

### DIFF
--- a/src/posting/app.py
+++ b/src/posting/app.py
@@ -853,6 +853,7 @@ class Posting(PostingApp):
                 # If there's no target (i.e. the user pressed ESC to dismiss)
                 # then re-focus the widget that was focused before we opened
                 # the jumper.
+                print("focused before", focused_before)
                 self.set_focus(focused_before, scroll_visible=False)
 
         self.clear_notifications()

--- a/src/posting/jump_overlay.py
+++ b/src/posting/jump_overlay.py
@@ -11,9 +11,11 @@ if TYPE_CHECKING:
     from posting.jumper import Jumper
 
 
-class JumpOverlay(ModalScreen[str | Widget]):
+class JumpOverlay(ModalScreen[str | Widget | None]):
     """Overlay showing the jump targets.
-    Returns the ID of the widget the jump was requested for on closing."""
+    Dismissed with the ID of the widget the jump was requested for on closing,
+    or a reference to the widget. Is dismissed with None if the user dismissed
+    the overlay without making a selection."""
 
     DEFAULT_CSS = """\
     JumpOverlay {
@@ -58,7 +60,7 @@ class JumpOverlay(ModalScreen[str | Widget]):
                 return
 
     def action_dismiss_overlay(self) -> None:
-        self.dismiss()
+        self.dismiss(None)
 
     async def on_resize(self) -> None:
         self._sync()

--- a/src/posting/jump_overlay.py
+++ b/src/posting/jump_overlay.py
@@ -17,6 +17,7 @@ class JumpOverlay(ModalScreen[str | Widget | None]):
     or a reference to the widget. Is dismissed with None if the user dismissed
     the overlay without making a selection."""
 
+    AUTO_FOCUS = None
     DEFAULT_CSS = """\
     JumpOverlay {
         background: black 25%;

--- a/src/posting/widgets/text_area.py
+++ b/src/posting/widgets/text_area.py
@@ -201,8 +201,8 @@ class TextAreaFooter(Horizontal):
 
 class PostingTextArea(TextArea):
     BINDINGS = [
-        Binding("f3", "open_in_pager", "Pager"),
-        Binding("f4", "open_in_editor", "Editor"),
+        Binding("f3,ctrl+P", "open_in_pager", "Pager"),
+        Binding("f4,ctrl+E", "open_in_editor", "Editor"),
     ]
 
     def on_mount(self) -> None:
@@ -235,6 +235,13 @@ class PostingTextArea(TextArea):
 
     def action_open_in_editor(self) -> None:
         editor_command = SETTINGS.get().editor
+        if not editor_command:
+            self.app.notify(
+                severity="warning",
+                title="No editor configured",
+                message="Set the [b]$EDITOR[/b] environment variable.",
+            )
+            return
         self._open_as_tempfile(editor_command)
 
     def action_open_in_pager(self) -> None:

--- a/src/posting/widgets/text_area.py
+++ b/src/posting/widgets/text_area.py
@@ -331,11 +331,14 @@ class ReadOnlyTextArea(PostingTextArea):
         Binding(
             "v",
             "toggle_visual_mode",
-            description="Select mode",
-            key_display="v",
+            description="Toggle visual mode",
+            show=False,
         ),
         Binding(
-            "y,c", "copy_to_clipboard", description="Copy selection", key_display="y"
+            "y,c",
+            "copy_to_clipboard",
+            description="Copy selection",
+            show=False,
         ),
         Binding("g", "cursor_top", "Go to top", show=False),
         Binding("G", "cursor_bottom", "Go to bottom", show=False),

--- a/src/posting/widgets/text_area.py
+++ b/src/posting/widgets/text_area.py
@@ -271,10 +271,7 @@ class PostingTextArea(TextArea):
 
         self._open_as_tempfile(pager_command)
 
-    def _open_as_tempfile(self, command: str | None) -> None:
-        if command is None:
-            return
-
+    def _open_as_tempfile(self, command: str) -> None:
         editor_args: list[str] = shlex.split(command)
 
         if self.language in {"json", "html", "yaml"}:
@@ -292,7 +289,14 @@ class PostingTextArea(TextArea):
         editor_args.append(temp_file_name)
 
         with self.app.suspend():
-            subprocess.call(editor_args)
+            try:
+                subprocess.call(editor_args)
+            except OSError:
+                self.app.notify(
+                    severity="error",
+                    title="Can't run command",
+                    message=f"The command [b]{command}[/b] failed to run.",
+                )
 
         with open(temp_file_name, "r") as temp_file:
             if not self.read_only:

--- a/src/posting/widgets/text_area.py
+++ b/src/posting/widgets/text_area.py
@@ -242,6 +242,7 @@ class PostingTextArea(TextArea):
                 message="Set the [b]$EDITOR[/b] environment variable.",
             )
             return
+
         self._open_as_tempfile(editor_command)
 
     def action_open_in_pager(self) -> None:
@@ -251,8 +252,22 @@ class PostingTextArea(TextArea):
         # want to use a specific pager for JSON, let's use that.
         if self.language == "json" and settings.pager_json:
             pager_command = settings.pager_json
+            if not pager_command:
+                self.app.notify(
+                    severity="warning",
+                    title="No JSON pager configured",
+                    message="Set the [b]$POSTING_PAGER_JSON[/b] environment variable.",
+                )
+                return
         else:
             pager_command = settings.pager
+            if not pager_command:
+                self.app.notify(
+                    severity="warning",
+                    title="No pager configured",
+                    message="Set the [b]$POSTING_PAGER[/b] environment variable.",
+                )
+                return
 
         self._open_as_tempfile(pager_command)
 


### PR DESCRIPTION
- Fix: workaround jump mode styling issue (awaiting upcoming Textual fix).
- Fix: collection tree wouldn't be refocused if jump mode was dismissed.
- Add: extra bindings - `ctrl+P` in a TextArea opens pager, `ctrl+E` opens editor. This is in addition to the existing `f3` and `f4` bindings.
- Add: warning toast if user attempts to open pager/editor but none are configured in the environment.
- Add: error toast if the user attempts to open pager/editor, but it fails to run due to an OSError.