### PR TITLE
Format request body that contains unicode as multi-line in .save_to_disk() (fix #48)

### DIFF
--- a/src/posting/collection.py
+++ b/src/posting/collection.py
@@ -226,9 +226,15 @@ class RequestModel(BaseModel):
     def save_to_disk(self, path: Path) -> None:
         """Save the request model to a YAML file."""
         content = self.model_dump(exclude_defaults=True, exclude_none=True)
-        yaml_content = yaml.dump(content, None, sort_keys=False)
+        yaml_content = yaml.dump(
+            content,
+            None,
+            sort_keys=False,
+            allow_unicode=True,
+        )
+        encoded_content = yaml_content.encode("ascii", errors="backslashreplace")
         path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_text(yaml_content)
+        path.write_bytes(encoded_content)
 
 
 class Contact(BaseModel):


### PR DESCRIPTION
This PR fixes #48 by passing `allow_unicode=True` to `yaml.dump()`. Since doing only that would include unicode characters in saved response content (which would necessitate special care when writing and reading files), we also encode to ascii with backslashreplace and save the resulting bytes.

A possible test would be:
```python
from pathlib import Path

import yaml

from posting.collection import RequestModel

sample = """name: Test
method: POST
url: https://example.org/test
body:
  content: |-
    {
      "Hello": "There",
      "Hi": "Čau"
    }"""

request = yaml.load(sample, Loader=yaml.SafeLoader)
req = RequestModel(**request)
output = Path("output.yaml")
req.save_to_disk(output)
contents = Path("output.yaml").read_text()
print(contents)
contents_body = yaml.load(contents, Loader=yaml.SafeLoader)["body"]["content"].encode("ascii")
request_body = request["body"]["content"].encode("ascii", errors="backslashreplace")
assert contents_body == request_body
```