### PR TITLE
Add curl import functionality

### DIFF
--- a/src/posting/app.py
+++ b/src/posting/app.py
@@ -694,7 +694,17 @@ class MainScreen(Screen[None]):
         )
 
     def on_curl_message(self, event: CurlMessage):
-        curl_import = CurlImport(event.curl_command)
+        try:
+            curl_import = CurlImport(event.curl_command)
+        except SystemExit:
+            self.notify(
+                title="Could not parse curl request",
+                message="An error occurred while parsing the curl request.",
+                timeout=5,
+                severity="error",
+            )
+            return
+
         self.headers_table.replace_all_rows(curl_import.headers)
         self.url_input.value = curl_import.url
 
@@ -705,15 +715,18 @@ class MainScreen(Screen[None]):
         if curl_import.is_form_data:
             self.request_editor.request_body_type_select.value = "form-body-editor"
             self.request_editor.form_editor.replace_all_rows(curl_import.data_pairs)
-            self.request_body_text_area.text = ""
         elif curl_import.data:
-            self.request_editor.form_editor.replace_all_rows([])
             self.request_editor.request_body_type_select.value = "text-body-editor"
             self.request_body_text_area.text = curl_import.data
         else:
             self.request_editor.request_body_type_select.value = "no-body-label"
 
         self.method_selector.value = curl_import.method
+        self.notify(
+            title="Curl request imported",
+            message=f"Successfully imported curl request to {curl_import.url}",
+            timeout=3,
+        )
 
     def load_request_model(self, request_model: RequestModel) -> None:
         """Load a request model into the UI."""

--- a/src/posting/app.py
+++ b/src/posting/app.py
@@ -721,6 +721,9 @@ class MainScreen(Screen[None]):
         else:
             self.request_editor.request_body_type_select.value = "no-body-label"
 
+        if curl_import.insecure:
+            self.request_options.verify_ssl_checkbox.value = False
+
         self.method_selector.value = curl_import.method
         self.notify(
             title="Curl request imported",

--- a/src/posting/importing/curl.py
+++ b/src/posting/importing/curl.py
@@ -1,0 +1,131 @@
+import argparse
+import shlex
+
+
+class CurlImport:
+    def __init__(self, curl_command):
+        # Remove leading 'curl ' if present
+        if curl_command.strip().startswith("curl "):
+            curl_command = curl_command.strip()[5:]
+
+        curl_command = curl_command.replace("\\\n", " ")
+        curl_command = curl_command.replace("\\", " ")
+
+        # Split the command string into tokens
+        tokens = shlex.split(curl_command)
+        parser = argparse.ArgumentParser()
+        # Define the arguments to parse
+        parser.add_argument("-X", "--request", help="Specify request command to use")
+        parser.add_argument(
+            "-H", "--header", action="append", help="Pass custom header(s) to server"
+        )
+        parser.add_argument("-d", "--data", help="HTTP POST data")
+        parser.add_argument("--data-raw", help="HTTP POST raw data")
+        parser.add_argument("--data-binary", help="HTTP POST binary data")
+        parser.add_argument(
+            "-F", "--form", action="append", help="Specify multipart MIME data"
+        )
+        parser.add_argument("-u", "--user", help="Server user and password")
+        parser.add_argument(
+            "--compressed", action="store_true", help="Request compressed response"
+        )
+        parser.add_argument(
+            "-k",
+            "--insecure",
+            action="store_true",
+            help="Allow insecure server connections when using SSL",
+        )
+        parser.add_argument("-e", "--referer", help="Referrer URL")
+        parser.add_argument("-A", "--user-agent", help="User-Agent to send to server")
+        parser.add_argument("url", nargs="?")
+        # Parse the arguments
+        args = parser.parse_intermixed_args(tokens)
+        # Extract components
+        self.method = args.request or (
+            "POST"
+            if args.data or args.form or args.data_raw or args.data_binary
+            else "GET"
+        )
+        self.headers = (
+            [header.split(": ") for header in args.header] if args.header else []
+        )
+        self.url = args.url
+        self.user = args.user
+        self.compressed = args.compressed
+        self.insecure = args.insecure
+        self.referer = args.referer
+        self.user_agent = args.user_agent
+
+        # Determine if the data is form data
+        self.is_form_data = False
+        content_type_header = next(
+            (value for name, value in self.headers if name.lower() == "content-type"),
+            "",
+        ).lower()
+
+        if args.form:
+            self.is_form_data = True
+        elif args.data or args.data_raw or args.data_binary:
+            if "application/x-www-form-urlencoded" in content_type_header:
+                self.is_form_data = True
+            elif not any("content-type" in h.lower() for h, _ in self.headers):
+                # Default content type for -d is application/x-www-form-urlencoded
+                self.is_form_data = True
+
+        # Store raw data
+        self.data = args.data or args.data_raw or args.data_binary
+
+        # Parse data into key-value pairs if it is form data
+        if self.is_form_data and self.data:
+            self.data_pairs = self.parse_data(self.data)
+        else:
+            self.data_pairs = []  # Not form data, so no key-value pairs
+
+        # Parse form data into key-value pairs
+        if args.form:
+            self.form = self.parse_form(args.form)
+        else:
+            self.form = []
+
+    def parse_data(self, data_str):
+        """Parse the data string into a list of tuples."""
+        if not data_str:
+            return []
+        pairs = data_str.split("&")
+        data = []
+        for pair in pairs:
+            if "=" in pair:
+                key, value = pair.split("=", 1)
+                data.append((key, value))
+            else:
+                data.append((pair, ""))
+        return data
+
+    def parse_form(self, form_list):
+        """Parse the form data into a list of tuples."""
+        if not form_list:
+            return []
+        form_data = []
+        for item in form_list:
+            if "=" in item:
+                key, value = item.split("=", 1)
+                form_data.append((key, value))
+            else:
+                form_data.append((item, ""))
+        return form_data
+
+    def as_dict(self):
+        return {
+            "method": self.method,
+            "url": self.url,
+            "headers": self.headers,
+            "data": self.data,
+            "data_pairs": self.data_pairs,
+            "form": self.form,
+            "user": self.user,
+            "compressed": self.compressed,
+            "insecure": self.insecure,
+            "referer": self.referer,
+            "user_agent": self.user_agent,
+            "is_form_data": self.is_form_data,
+        }

--- a/src/posting/importing/curl.py
+++ b/src/posting/importing/curl.py
@@ -46,9 +46,11 @@ class CurlImport:
             if args.data or args.form or args.data_raw or args.data_binary
             else "GET"
         )
-        self.headers = (
-            [header.split(": ") for header in args.header] if args.header else []
-        )
+        self.headers = []
+        for header in args.header or []:
+            name, sep, value = header.partition(":")
+            if sep:
+                self.headers.append([name.strip(), value.strip()])
         self.url = args.url
         self.user = args.user
         self.compressed = args.compressed

--- a/src/posting/importing/curl.py
+++ b/src/posting/importing/curl.py
@@ -3,11 +3,22 @@ import shlex
 
 
 class CurlImport:
+    """
+    Parses a curl command string and extracts HTTP request components.
+    """
+
     def __init__(self, curl_command):
+        """
+        Initialize the parser with a curl command.
+
+        Args:
+            curl_command (str): The curl command string to parse.
+        """
         # Remove leading 'curl ' if present
         if curl_command.strip().startswith("curl "):
             curl_command = curl_command.strip()[5:]
 
+        # Replace line breaks and `\`. If we don't do this, argparse can crash when pasting requests from chrome
         curl_command = curl_command.replace("\\\n", " ")
         curl_command = curl_command.replace("\\", " ")
 
@@ -38,7 +49,7 @@ class CurlImport:
         parser.add_argument("-e", "--referer", help="Referrer URL")
         parser.add_argument("-A", "--user-agent", help="User-Agent to send to server")
         parser.add_argument("url", nargs="?")
-        # Parse the arguments
+
         args = parser.parse_intermixed_args(tokens)
         # Extract components
         self.method = args.request or (

--- a/src/posting/widgets/request/url_bar.py
+++ b/src/posting/widgets/request/url_bar.py
@@ -7,7 +7,7 @@ from textual.binding import Binding
 from textual.containers import Horizontal, Vertical
 from textual.css.query import NoMatches
 from textual.design import ColorSystem
-from textual.events import Blur
+from textual.events import Blur, Paste
 from textual.message import Message
 from textual.widgets import Input, Button, Label
 from textual_autocomplete import DropdownItem
@@ -26,6 +26,12 @@ from posting.widgets.input import PostingInput
 from posting.widgets.request.method_selection import MethodSelector
 from posting.widgets.response.response_trace import Event
 from posting.widgets.variable_autocomplete import VariableAutoComplete
+
+
+class CurlMessage(Message):
+    def __init__(self, curl_command):
+        super().__init__()
+        self.curl_command = curl_command
 
 
 class UrlInput(PostingInput):
@@ -103,6 +109,12 @@ Press `ctrl+l` to quickly focus this bar from elsewhere.""",
             self.highlighter.variable_styles = theme.variable.fill_with_defaults(theme)
         if theme.url:
             self.highlighter.url_styles = theme.url.fill_with_defaults(theme)
+
+    def on_paste(self, event: Paste):
+        if not event.text.startswith("curl "):
+            return
+        event.prevent_default()
+        self.post_message(CurlMessage(event.text))
 
 
 class SendRequestButton(Button, can_focus=False):

--- a/tests/test_curl_import.py
+++ b/tests/test_curl_import.py
@@ -175,13 +175,6 @@ def test_curl_with_complex_command():
     assert curl_import.is_form_data is False
 
 
-def test_curl_with_insecure():
-    """Test parsing of --insecure flag."""
-    curl_command = "curl -k http://example.com"
-    curl_import = CurlImport(curl_command)
-    assert curl_import.insecure is True
-
-
 def test_curl_with_utf8_characters():
     """Test curl command with UTF-8 characters."""
     curl_command = "curl -d 'param=テスト' http://example.com"

--- a/tests/test_curl_import.py
+++ b/tests/test_curl_import.py
@@ -1,0 +1,195 @@
+import pytest
+from posting.importing.curl import CurlImport
+
+
+def test_simple_get():
+    """Test a simple GET request."""
+    curl_command = "curl http://example.com"
+    curl_import = CurlImport(curl_command)
+    assert curl_import.method == "GET"
+    assert curl_import.url == "http://example.com"
+    assert curl_import.headers == []
+    assert curl_import.data is None
+
+
+def test_get_with_headers():
+    """Test GET request with headers."""
+    curl_command = "curl -H 'Accept: application/json' -H 'User-Agent: TestAgent' http://example.com"
+    curl_import = CurlImport(curl_command)
+    assert curl_import.method == "GET"
+    assert curl_import.url == "http://example.com"
+    assert curl_import.headers == [
+        ["Accept", "application/json"],
+        ["User-Agent", "TestAgent"],
+    ]
+    assert curl_import.data is None
+
+
+def test_post_with_form_data():
+    """Test POST request with form data using -d."""
+    curl_command = "curl -X POST -d 'key1=value1&key2=value2' http://example.com"
+    curl_import = CurlImport(curl_command)
+    assert curl_import.method == "POST"
+    assert curl_import.url == "http://example.com"
+    assert curl_import.data == "key1=value1&key2=value2"
+    assert curl_import.is_form_data is True
+    assert curl_import.data_pairs == [("key1", "value1"), ("key2", "value2")]
+
+
+def test_post_with_json_data():
+    """Test POST request with JSON data."""
+    curl_command = "curl -X POST -H 'Content-Type: application/json' -d '{\"key\":\"value\"}' http://example.com"
+    curl_import = CurlImport(curl_command)
+    assert curl_import.method == "POST"
+    assert curl_import.url == "http://example.com"
+    assert curl_import.data == '{"key":"value"}'
+    assert curl_import.is_form_data is False
+    assert curl_import.data_pairs == []
+
+
+def test_post_with_form_option():
+    """Test POST request with form data using -F."""
+    curl_command = (
+        "curl -X POST -F 'field1=value1' -F 'field2=value2' http://example.com"
+    )
+    curl_import = CurlImport(curl_command)
+    assert curl_import.method == "POST"
+    assert curl_import.url == "http://example.com"
+    assert curl_import.form == [("field1", "value1"), ("field2", "value2")]
+    assert curl_import.is_form_data is True
+
+
+def test_multiple_data_options():
+    """Test handling of multiple -d options."""
+    curl_command = "curl -d 'key1=value1' -d 'key2=value2' http://example.com"
+    curl_import = CurlImport(curl_command)
+    # Depending on implementation, data might be concatenated or last one used
+    assert (
+        curl_import.data == "key1=value1key2=value2"
+        or curl_import.data == "key2=value2"
+    )
+    assert curl_import.is_form_data is True
+    assert curl_import.data_pairs in (
+        [("key1", "value1"), ("key2", "value2")],
+        [("key2", "value2")],
+    )
+
+
+def test_curl_with_user_and_password():
+    """Test parsing of user credentials."""
+    curl_command = "curl -u username:password http://example.com"
+    curl_import = CurlImport(curl_command)
+    assert curl_import.user == "username:password"
+    assert curl_import.url == "http://example.com"
+
+
+def test_curl_with_insecure():
+    """Test parsing of --insecure flag."""
+    curl_command = "curl -k http://example.com"
+    curl_import = CurlImport(curl_command)
+    assert curl_import.insecure is True
+
+
+def test_curl_with_referer():
+    """Test parsing of referer."""
+    curl_command = "curl -e 'http://referrer.com' http://example.com"
+    curl_import = CurlImport(curl_command)
+    assert curl_import.referer == "http://referrer.com"
+
+
+def test_curl_with_user_agent():
+    """Test parsing of user-agent."""
+    curl_command = "curl -A 'CustomAgent' http://example.com"
+    curl_import = CurlImport(curl_command)
+    assert curl_import.user_agent == "CustomAgent"
+
+
+def test_curl_with_compressed():
+    """Test parsing of --compressed flag."""
+    curl_command = "curl --compressed http://example.com"
+    curl_import = CurlImport(curl_command)
+    assert curl_import.compressed is True
+
+
+def test_curl_with_method_and_data():
+    """Test custom method with data."""
+    curl_command = "curl -X PUT -d 'key=value' http://example.com"
+    curl_import = CurlImport(curl_command)
+    assert curl_import.method == "PUT"
+    assert curl_import.data == "key=value"
+    assert curl_import.is_form_data is True
+
+
+def test_curl_with_data_raw():
+    """Test parsing of --data-raw."""
+    curl_command = "curl --data-raw 'raw data' http://example.com"
+    curl_import = CurlImport(curl_command)
+    assert curl_import.data == "raw data"
+    assert curl_import.is_form_data is True
+
+
+def test_curl_with_data_binary():
+    """Test parsing of --data-binary."""
+    curl_command = "curl --data-binary 'binary data' http://example.com"
+    curl_import = CurlImport(curl_command)
+    assert curl_import.data == "binary data"
+    assert curl_import.is_form_data is True
+
+
+def test_curl_with_escaped_newlines():
+    """Test parsing of curl command with escaped newlines."""
+    curl_command = """curl -X POST \\
+    -H 'Content-Type: application/json' \\
+    -d '{"key": "value"}' \\
+    http://example.com"""
+    curl_import = CurlImport(curl_command)
+    assert curl_import.method == "POST"
+    assert curl_import.url == "http://example.com"
+    assert curl_import.data == '{"key": "value"}'
+    assert curl_import.headers == [["Content-Type", "application/json"]]
+
+
+def test_curl_with_no_space_in_header():
+    """Test headers without space after colon."""
+    curl_command = "curl -H 'Authorization:Bearer token' http://example.com"
+    curl_import = CurlImport(curl_command)
+    assert curl_import.headers == [["Authorization", "Bearer token"]]
+
+
+def test_curl_with_complex_command():
+    """Test a complex curl command."""
+    curl_command = (
+        "curl -X POST -H 'Accept: application/json' -H 'Content-Type: application/json' "
+        '-d \'{"name":"test","value":123}\' --compressed --insecure '
+        "http://example.com/api/test"
+    )
+    curl_import = CurlImport(curl_command)
+    assert curl_import.method == "POST"
+    assert curl_import.url == "http://example.com/api/test"
+    assert curl_import.headers == [
+        ["Accept", "application/json"],
+        ["Content-Type", "application/json"],
+    ]
+    assert curl_import.data == '{"name":"test","value":123}'
+    assert curl_import.compressed is True
+    assert curl_import.insecure is True
+    assert curl_import.is_form_data is False
+
+
+def test_curl_with_utf8_characters():
+    """Test curl command with UTF-8 characters."""
+    curl_command = "curl -d 'param=テスト' http://example.com"
+    curl_import = CurlImport(curl_command)
+    assert curl_import.data == "param=テスト"
+    assert curl_import.data_pairs == [("param", "テスト")]
+
+
+def test_curl_with_special_characters_in_data():
+    """Test data containing special characters."""
+    curl_command = "curl -d 'param=hello%20world&key=value%3Dtest' http://example.com"
+    curl_import = CurlImport(curl_command)
+    assert curl_import.data == "param=hello%20world&key=value%3Dtest"
+    assert curl_import.data_pairs == [
+        ("param", "hello%20world"),
+        ("key", "value%3Dtest"),
+    ]

--- a/tests/test_curl_import.py
+++ b/tests/test_curl_import.py
@@ -1,4 +1,3 @@
-import pytest
 from posting.importing.curl import CurlImport
 
 

--- a/tests/test_curl_import.py
+++ b/tests/test_curl_import.py
@@ -176,6 +176,13 @@ def test_curl_with_complex_command():
     assert curl_import.is_form_data is False
 
 
+def test_curl_with_insecure():
+    """Test parsing of --insecure flag."""
+    curl_command = "curl -k http://example.com"
+    curl_import = CurlImport(curl_command)
+    assert curl_import.insecure is True
+
+
 def test_curl_with_utf8_characters():
     """Test curl command with UTF-8 characters."""
     curl_command = "curl -d 'param=テスト' http://example.com"


### PR DESCRIPTION
This PR adds support for pasting a cURL command in the URL bar as discussed here: https://github.com/darrenburns/posting/discussions/73

Here's a quick demo:

https://github.com/user-attachments/assets/8a2aa699-ea04-4756-a874-5ad21a14e2ce

In this demo you can see that the headers are parsed correctly, the data is parsed correctly and the `--insecure` flag disables the `Verify SSL certificates` option.

There might be some edge cases that it can't handle, in which case it will display a message to the user. Testing with curl requests from chrome seems to work.