### PR TITLE
PEP8: Never use equality operators to compare to singletons

### DIFF
--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -42,7 +42,7 @@ def test_is_valid_filename(filename, expected):
 
 
 def test_is_valid_filename_with_none():
-    assert is_valid_filename(None) == False
+    assert is_valid_filename(None) is False
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
https://peps.python.org/pep-0008/#programming-recommendations
> Comparisons to singletons like None should always be done with `is` or `is not`, never the equality operators.

% `ruff rule E712`
# true-false-comparison (E712)

Derived from the **pycodestyle** linter.

Fix is always available.

## What it does
Checks for equality comparisons to boolean literals.

## Why is this bad?
[PEP 8] recommends against using the equality operators `==` and `!=` to
compare values to `True` or `False`.

Instead, use `if cond:` or `if not cond:` to check for truth values.

If you intend to check if a value is the boolean literal `True` or `False`,
consider using `is` or `is not` to check for identity instead.

## Example
```python
if foo == True:
    ...

if bar == False:
    ...
```

Use instead:
```python
if foo:
    ...

if not bar:
    ...
```

## Fix safety

This rule's fix is marked as unsafe, as it may alter runtime behavior when
used with libraries that override the `==`/`__eq__` or `!=`/`__ne__` operators.
In these cases, `is`/`is not` may not be equivalent to `==`/`!=`. For more
information, see [this issue].

[PEP 8]: https://peps.python.org/pep-0008/#programming-recommendations
[this issue]: https://github.com/astral-sh/ruff/issues/4560
