### PR TITLE
Add sender option to add_row function

### DIFF
--- a/src/posting/widgets/datatable.py
+++ b/src/posting/widgets/datatable.py
@@ -5,6 +5,7 @@ from textual import on
 from textual.binding import Binding
 from textual.coordinate import Coordinate
 from textual.message import Message
+from textual.message_pump import MessagePump
 from textual.widgets import DataTable
 from textual.widgets.data_table import CellDoesNotExist, CellKey, RowKey
 
@@ -59,8 +60,12 @@ PostingDataTable {
         key: str | None = None,
         label: str | Text | None = None,
         explicit_by_user: bool = True,
+        sender: MessagePump | None = None,
     ) -> RowKey:
-        self.post_message(self.RowsAdded(self, explicit_by_user=explicit_by_user))
+        msg = self.RowsAdded(self, explicit_by_user=explicit_by_user)
+        if sender:
+            msg.set_sender(sender)
+        self.post_message(msg)
         return super().add_row(*cells, height=height, key=key, label=label)
 
     def action_toggle_fixed_columns(self) -> None:

--- a/src/posting/widgets/key_value.py
+++ b/src/posting/widgets/key_value.py
@@ -143,7 +143,7 @@ class KeyValueEditor(Vertical):
     @on(KeyValueInput.New)
     def add_key_value_pair(self, event: KeyValueInput.New) -> None:
         table = self.table
-        table.add_row(event.key, event.value)
+        table.add_row(event.key, event.value, sender=table)
         table.move_cursor(row=table.row_count - 1)
 
     @on(PostingDataTable.RowsRemoved)


### PR DESCRIPTION
fix: https://github.com/darrenburns/posting/issues/105

https://github.com/Textualize/textual/blob/8d99130708b3a862fc849884e0015c2c864345d1/src/textual/message_pump.py#L780-L785

Due to the message bubble logic in textual, when a parent element invokes a method of a child element, and the method posts a message, the sender is actually the parent element itself, which prevents the message from being passed to the grandparent element. The `sender` option has now been added to explicitly specify the sender as the child element.