### PR TITLE
Added error messages for read and write timeouts

### DIFF
--- a/src/posting/app.py
+++ b/src/posting/app.py
@@ -425,6 +425,20 @@ class MainScreen(Screen[None]):
                 title="Connect timeout",
                 message=f"Couldn't connect within {request_options.timeout} seconds.",
             )
+        except httpx.ReadTimeout as read_timeout:
+            log.error("Read timeout", read_timeout)
+            self.notify(
+                severity="error",
+                title="Read timeout",
+                message=f"Couldn't read data within {request_options.timeout} seconds.",
+            )
+        except httpx.WriteTimeout as write_timeout:
+            log.error("Write timeout", write_timeout)
+            self.notify(
+                severity="error",
+                title="Write timeout",
+                message=f"Couldn't send data within {request_options.timeout} seconds.",
+            )
         except Exception as e:
             log.error("Error sending request", e)
             log.error("Type of error", type(e))


### PR DESCRIPTION
While working with some slow API I ran into an error "Couldn't send request" and it wasn't immediately obvious what was causing it, given that exported `curl` was working as expected. So I decided to make this small improvement to error handling.

Before:
![notification-before](https://github.com/user-attachments/assets/525413b6-8f77-4aee-9de7-077aba74e7e2)
After:
![notification-after](https://github.com/user-attachments/assets/cb0d9998-e5ba-4b78-b50e-1af782811895)
