### PR TITLE
Feature: Add File Upload in request form-data

### DIFF
--- a/src/posting/collection.py
+++ b/src/posting/collection.py
@@ -263,13 +263,11 @@ class RequestModel(BaseModel):
 
     def to_httpx(self, client: httpx.AsyncClient) -> httpx.Request:
         """Convert the request model to an httpx request."""
-        headers = httpx.Headers(
-            {
-                header.name: header.value
-                for header in self.headers
-                if header.enabled and header.name.lower() != "content-type"
-            }
-        )
+        headers = httpx.Headers([
+            (header.name, header.value)
+            for header in self.headers
+            if header.enabled and header.name.lower() != "content-type"
+        ])
 
         httpx_args = self.body.to_httpx_args() if self.body else {}
 


### PR DESCRIPTION
Addressing Issue: #224 
- Added a file upload option when the form data value has `@` before the file path as convention form the [curl -F option](https://curl.se/docs/manpage.html#-F)
- Override the request content-type header dynamically with httpx
- Segregate files and data in the formdata of request

Minor changes:
- Refactor the data key to be default as defaultdict of list
- We separate the key-value pairs from the file type fields if there is `@` in the start of a value

Hope that is a quick and correct approach right now with the file upload part?
Let me know for any suggestions or improvements, thanks