### PR TITLE
Fix a special case when url variables contain protocol/schema

### DIFF
--- a/src/posting/app.py
+++ b/src/posting/app.py
@@ -740,7 +740,7 @@ class MainScreen(Screen[None]):
             path=open_request.path if open_request else None,
             description=self.request_metadata.description,
             method=self.selected_method,
-            url=self.url_input.value_including_protocol,
+            url=self.url_input.value.strip(),
             params=self.params_table.to_model(),
             headers=headers,
             options=request_options,

--- a/src/posting/collection.py
+++ b/src/posting/collection.py
@@ -14,6 +14,7 @@ from posting.tuple_to_multidict import tuples_to_dict
 from posting.variables import SubstitutionError
 from posting.version import VERSION
 from posting.yaml import dump, load, Loader
+from posting.urls import ensure_protocol
 
 HttpRequestMethod = Literal["GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS"]
 VALID_HTTP_METHODS = get_args(HttpRequestMethod)
@@ -197,7 +198,7 @@ class RequestModel(BaseModel):
         """Apply the template to the request model."""
         try:
             template = Template(self.url)
-            self.url = template.substitute(variables)
+            self.url = ensure_protocol(template.substitute(variables))
 
             template = Template(self.description)
             self.description = template.substitute(variables)

--- a/src/posting/widgets/request/url_bar.py
+++ b/src/posting/widgets/request/url_bar.py
@@ -108,10 +108,6 @@ It's recommended you create a new request before pasting a curl command, to avoi
         event.prevent_default()
         self.post_message(CurlMessage(event.text))
 
-    @property
-    def value_including_protocol(self) -> str:
-        return ensure_protocol(self.value.strip())
-
 
 class SendRequestButton(Button, can_focus=False):
     """


### PR DESCRIPTION
e.g. BASE_URL=https://foo.com

It's inappropriate to use `ensure_protocol` prematurely; it should be deferred until after `apply_template`.