### PR TITLE
Fix script path with custom function

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 - Exported curl command uses `-d` for form data now, rather than `-F`. The result is exported commands with form data will now use `application/x-www-form-urlencoded` instead of `multipart/form-data` (matching Posting's behaviour). [(#252)](https://github.com/darrenburns/posting/pull/252)
 - Fix attempting to add a protocol before applying variables in the URL bar [(#248)](https://github.com/darrenburns/posting/pull/248)
-
+- Fix script path with custom function [(#254)](https://github.com/darrenburns/posting/pull/254)
 
 ## 2.6.0 [29th March 2025]
 

--- a/src/posting/app.py
+++ b/src/posting/app.py
@@ -276,12 +276,12 @@ class MainScreen(Screen[None]):
             write_logs_to_ui: Whether to write logs to the UI.
             *args: Arguments to pass to the script function.
         """
-        script_path = Path(path_to_script)
-        path_name_parts = script_path.name.split(":")
+        path_name_parts = path_to_script.split(":")
         if len(path_name_parts) == 2:
             script_path = Path(path_name_parts[0])
             function_name = path_name_parts[1]
         else:
+            script_path = Path(path_to_script)
             function_name = default_function_name
 
         try:


### PR DESCRIPTION
Howdy :wave:

I came across a bug when providing a custom scripting function in the script path that would only include the script filename and not any of the preceding path.

For example: `scripts/util.py:custom_func` would become `util.py` with `custom_func` as the function to call. This very small pull request fixes that behavior.

Please let me know if I missed anything in the contribution guidlines and I'll be happy to fix it. Thanks!