### PR TITLE
Add UTF-8 encoding to file open operation

### DIFF
--- a/src/posting/collection.py
+++ b/src/posting/collection.py
@@ -559,6 +559,6 @@ def load_request_from_yaml(file_path: str) -> RequestModel:
     Returns:
         RequestModel: The request model loaded from the YAML file.
     """
-    with open(file_path, "r") as file:
+    with open(file_path, "r", encoding="utf-8") as file:
         data = load(file, Loader=Loader)
         return RequestModel(**data, path=Path(file_path))


### PR DESCRIPTION
Specify UTF-8 encoding when opening the collection file. 
The collection file specified 'utf-8' when writing, but no encoding was specified when reading.
```py
    def save_to_disk(self, path: Path) -> None:
        """Save the request model to a YAML file."""
        content = self.model_dump(exclude_defaults=True, exclude_none=True)
        yaml_content = dump(
            content,
            None,
            sort_keys=False,
            allow_unicode=True,
        )
        path.parent.mkdir(parents=True, exist_ok=True)
        path.write_text(yaml_content, encoding="utf-8")
```
```py
def load_request_from_yaml(file_path: str) -> RequestModel:
    """Load a request model from a YAML file.

    Args:
        file_path: The path to the YAML file.

    Returns:
        RequestModel: The request model loaded from the YAML file.
    """
    with open(file_path, "r") as file:
        data = load(file, Loader=Loader)
        return RequestModel(**data, path=Path(file_path))
```