### PR TITLE
Fix: Remove duplicate auth field in RequestModel

### DIFF
--- a/src/posting/collection.py
+++ b/src/posting/collection.py
@@ -187,11 +187,8 @@ class RequestModel(BaseModel):
 
     cookies: list[Cookie] = Field(default_factory=list, exclude=True)
     """The cookies of the request.
-    
-    These are excluded because they should not be persisted to the request file."""
 
-    auth: Auth | None = Field(default=None)
-    """The auth information for the request."""
+    These are excluded because they should not be persisted to the request file."""
 
     posting_version: str = Field(default=VERSION)
     """The version of Posting."""


### PR DESCRIPTION
## Root Cause

The `RequestModel` class in `src/posting/collection.py` had the `auth` field defined twice (lines 176 and 193). This is a Pydantic modeling error â€” defining the same field name twice in a `BaseModel` causes undefined behavior and can trigger validation errors.

## Original Code

```python
class RequestModel(BaseModel):
    ...
    auth: Auth | None = Field(default=None)   # Line 176
    headers: list[Header] = Field(default_factory=list)
    ...
    cookies: list[Cookie] = Field(default_factory=list, exclude=True)

    auth: Auth | None = Field(default=None)   # Line 193 (DUPLICATE)
    ...
```

## Fix

Remove the duplicate `auth` field definition. The first `auth` field (line 176) with docstring `The authentication information for the request.` is kept; the second (line 193, docstring `The auth information for the request.`) is removed.

134 unit tests pass with this change.